### PR TITLE
PHP 7.0 이상의 환경에서 Call to undefined function mysql_error() 오류 발생 문제 해결 #1

### DIFF
--- a/inc/zMigration.class.php
+++ b/inc/zMigration.class.php
@@ -183,7 +183,7 @@ class zMigration
 			case 'mysqli' :
 			case 'mysqli_innodb' :
 					$this->connect =  mysqli_connect($this->db_info->db_hostname, $this->db_info->db_userid, $this->db_info->db_password,$this->db_info->db_database,$this->db_info->db_port);
-					if(mysql_error()) return mysqli_error();
+					if(mysqli_error()) return mysqli_error();
 					if($this->source_charset == 'UTF-8') mysqli_query($this->connect, "set names 'utf8'");
 				break;
 			case 'cubrid' :


### PR DESCRIPTION
dev branch가 없어서 master로 pull request 넣어 봅니다.